### PR TITLE
Update minitest-rails-capybara.gemspec

### DIFF
--- a/minitest-rails-capybara.gemspec
+++ b/minitest-rails-capybara.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "minitest-rails-capybara"
-  s.version = "0.10.0.20140118163100"
+  s.version = "0.10.0.20140328135303"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Mike Moore"]
@@ -25,14 +25,14 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<minitest-rails>, ["~> 1.0.0.beta1"])
+      s.add_runtime_dependency(%q<minitest-rails>, ["~> 1.0.0.beta3"])
       s.add_runtime_dependency(%q<capybara>, ["~> 2.0"])
       s.add_runtime_dependency(%q<minitest-capybara>, ["~> 0.4"])
       s.add_runtime_dependency(%q<minitest-metadata>, ["~> 0.4"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<hoe>, ["~> 3.7"])
     else
-      s.add_dependency(%q<minitest-rails>, ["~> 1.0.0.beta1"])
+      s.add_dependency(%q<minitest-rails>, ["~> 1.0.0.beta3"])
       s.add_dependency(%q<capybara>, ["~> 2.0"])
       s.add_dependency(%q<minitest-capybara>, ["~> 0.4"])
       s.add_dependency(%q<minitest-metadata>, ["~> 0.4"])
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hoe>, ["~> 3.7"])
     end
   else
-    s.add_dependency(%q<minitest-rails>, ["~> 1.0.0.beta1"])
+    s.add_dependency(%q<minitest-rails>, ["~> 1.0.0.beta3"])
     s.add_dependency(%q<capybara>, ["~> 2.0"])
     s.add_dependency(%q<minitest-capybara>, ["~> 0.4"])
     s.add_dependency(%q<minitest-metadata>, ["~> 0.4"])


### PR DESCRIPTION
Bumped minitest-rails dependency to the 1.0.0.beta1 release
