### PR TITLE
updating minitest-capybara version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ Hoe.spec "minitest-rails-capybara" do
 
   dependency "minitest-rails",    "~> 2.0.0"
   dependency "capybara",          "~> 2.0"
-  dependency "minitest-capybara", "~> 0.6.1"
+  dependency "minitest-capybara", "~> 0.7.0"
   dependency "minitest-metadata", "~> 0.5.0"
 end
 

--- a/minitest-rails-capybara.gemspec
+++ b/minitest-rails-capybara.gemspec
@@ -26,14 +26,14 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<minitest-rails>, ["~> 2.0.0"])
       s.add_runtime_dependency(%q<capybara>, ["~> 2.0"])
-      s.add_runtime_dependency(%q<minitest-capybara>, ["~> 0.6.1"])
+      s.add_runtime_dependency(%q<minitest-capybara>, ["~> 0.7.0"])
       s.add_runtime_dependency(%q<minitest-metadata>, ["~> 0.5.0"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<hoe>, ["~> 3.11"])
     else
       s.add_dependency(%q<minitest-rails>, ["~> 2.0.0"])
       s.add_dependency(%q<capybara>, ["~> 2.0"])
-      s.add_dependency(%q<minitest-capybara>, ["~> 0.6.1"])
+      s.add_dependency(%q<minitest-capybara>, ["~> 0.7.0"])
       s.add_dependency(%q<minitest-metadata>, ["~> 0.5.0"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<hoe>, ["~> 3.11"])
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<minitest-rails>, ["~> 2.0.0"])
     s.add_dependency(%q<capybara>, ["~> 2.0"])
-    s.add_dependency(%q<minitest-capybara>, ["~> 0.6.1"])
+    s.add_dependency(%q<minitest-capybara>, ["~> 0.7.0"])
     s.add_dependency(%q<minitest-metadata>, ["~> 0.5.0"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<hoe>, ["~> 3.11"])


### PR DESCRIPTION
this update capybara to 2.2.0. all tests are green.

```
Finished in 0.106390s, 216.1857 runs/s, 582.7615 assertions/s.

23 runs, 62 assertions, 0 failures, 0 errors, 0 skips
```
