### PR TITLE
fix typo in example string

### DIFF
--- a/lib/generators/minitest/feature/templates/feature_spec.rb
+++ b/lib/generators/minitest/feature/templates/feature_spec.rb
@@ -4,6 +4,6 @@ feature "<%= class_name %>" do
   scenario "the test is sound" do
     visit root_path
     page.must_have_content "Hello World"
-    page.wont_have_content "Goobye All!"
+    page.wont_have_content "Goodbye All!"
   end
 end


### PR DESCRIPTION
As as endearing as "goobye" is, I think it's finally time to put this one to rest.