### PR TITLE
fix typo in example string

### DIFF
--- a/lib/generators/minitest/feature/templates/feature_test.rb
+++ b/lib/generators/minitest/feature/templates/feature_test.rb
@@ -4,6 +4,6 @@ class <%= class_name %>Test < Capybara::Rails::TestCase
   test "sanity" do
     visit root_path
     assert_content page, "Hello World"
-    refute_content page, "Goobye All!"
+    refute_content page, "Goodbye All!"
   end
 end


### PR DESCRIPTION
Hey, I just noticed the same typo as #29 but in the second template file :)