### PR TITLE
[issue#32] Bump the minitest-capybara dependency

### DIFF
--- a/minitest-rails-capybara.gemspec
+++ b/minitest-rails-capybara.gemspec
@@ -26,14 +26,14 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<minitest-rails>, ["~> 2.1"])
       s.add_runtime_dependency(%q<capybara>, ["~> 2.0"])
-      s.add_runtime_dependency(%q<minitest-capybara>, ["~> 0.7.0"])
+      s.add_runtime_dependency(%q<minitest-capybara>, ["~> 0.8.0"])
       s.add_runtime_dependency(%q<minitest-metadata>, ["~> 0.5.0"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<hoe>, ["~> 3.12"])
     else
       s.add_dependency(%q<minitest-rails>, ["~> 2.1"])
       s.add_dependency(%q<capybara>, ["~> 2.0"])
-      s.add_dependency(%q<minitest-capybara>, ["~> 0.7.0"])
+      s.add_dependency(%q<minitest-capybara>, ["~> 0.8.0"])
       s.add_dependency(%q<minitest-metadata>, ["~> 0.5.0"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<hoe>, ["~> 3.12"])
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<minitest-rails>, ["~> 2.1"])
     s.add_dependency(%q<capybara>, ["~> 2.0"])
-    s.add_dependency(%q<minitest-capybara>, ["~> 0.7.0"])
+    s.add_dependency(%q<minitest-capybara>, ["~> 0.8.0"])
     s.add_dependency(%q<minitest-metadata>, ["~> 0.5.0"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<hoe>, ["~> 3.12"])


### PR DESCRIPTION
From `~> 0.7.0` to `~> 0.8.0`

Resolve #32