### PR TITLE
Update bundler on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 before_install:
   - gem update --system
   - gem --version
+  - gem update bundler
 language: ruby
 notifications:
   email:


### PR DESCRIPTION
Fixes "undefined method `spec' for nil" failure on build

Example of failure: https://travis-ci.org/blowmage/minitest-rails-capybara/jobs/103579055