### PR TITLE
Rails 5 Support

### DIFF
--- a/minitest-rails-capybara.gemspec
+++ b/minitest-rails-capybara.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<minitest-rails>.freeze, ["~> 3.0"])
-      s.add_runtime_dependency(%q<capybara>.freeze, ["~> 2.7"])
+      s.add_runtime_dependency(%q<capybara>.freeze, [">= 2.7", "<= 4"])
       s.add_runtime_dependency(%q<minitest-capybara>.freeze, ["~> 0.8"])
       s.add_runtime_dependency(%q<minitest-metadata>.freeze, ["~> 0.6"])
       s.add_development_dependency(%q<rdoc>.freeze, ["~> 4.0"])

--- a/test/rails_helper.rb
+++ b/test/rails_helper.rb
@@ -5,6 +5,7 @@ require "action_controller/railtie"
 
 class TestApp < Rails::Application
   config.secret_token = "821c600ece97fc4ba952d67655b4b475"
+  config.eager_load = false
   initialize!
   routes.draw do
     root to: "hello#world"

--- a/test/test_dsl.rb
+++ b/test/test_dsl.rb
@@ -5,7 +5,7 @@ describe "Capybara DSL Feature Test" do
   it "can call using_wait_time" do
     ret = "ZOMG! using_wait_time was called!"
     Capybara.stub :using_wait_time, ret do
-      assert_equal ret, using_wait_time(6)
+      assert_equal ret, using_wait_time(6) {}
     end
   end
 


### PR DESCRIPTION
Loosing the specifications for minitest-rails seems to be all that's needed to support rails5!