### PR TITLE
fix dependency for rails6

### DIFF
--- a/minitest-rails-capybara.gemspec
+++ b/minitest-rails-capybara.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<minitest-rails>.freeze, ["~> 3.0"])
+      s.add_runtime_dependency(%q<minitest-rails>.freeze, [">= 3.0"])
       s.add_runtime_dependency(%q<capybara>.freeze, [">= 2.7", "<= 4"])
       s.add_runtime_dependency(%q<minitest-capybara>.freeze, ["~> 0.8"])
       s.add_runtime_dependency(%q<minitest-metadata>.freeze, ["~> 0.6"])

--- a/minitest-rails-capybara.gemspec
+++ b/minitest-rails-capybara.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<minitest-rails>.freeze, [">= 3.0"])
+      s.add_runtime_dependency(%q<minitest-rails>.freeze, [">= 5.0"])
       s.add_runtime_dependency(%q<capybara>.freeze, [">= 2.7", "<= 4"])
       s.add_runtime_dependency(%q<minitest-capybara>.freeze, ["~> 0.8"])
       s.add_runtime_dependency(%q<minitest-metadata>.freeze, ["~> 0.6"])


### PR DESCRIPTION
Hello.
I am currently working on my project update to rails6.
But I got the error message like follow.

```
Minitest::UnexpectedError:         Selenium::WebDriver::Error::NoSuchWindowError: no such window: target window already closed
        from unknown error: web view not found
          (Session info: chrome=81.0.4044.122)
            test/features/admin/article_ignore_ad/csv_export_test.rb:14:in `block (2 levels) in <main>'
```

Result of investigation, it was due to `minitest-capybara's` dependency.

minitest-capybara depend on capybara (~> 2.2), but I need capybara 3.2
In order to resolve this error, I fix Gemfile.lock and issue pull request.

